### PR TITLE
FIX added checking into sys.modules before trying to import base_globals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
-0.5.3.dev0
-==========
-- Fixed a pickling issue for ABC in python3.7+ ([issue #180](https://github.com/cloudpipe/cloudpickle/issues/180)).
+0.5.4
+=====
+
+- Fixed a pickling issue for ABC in python3.7+ ([issue #180](
+  https://github.com/cloudpipe/cloudpickle/issues/180)).
+
+- Fixed a bug when pickling functions in `__main__` that access global
+  variables ([issue #187](
+  https://github.com/cloudpipe/cloudpickle/issues/187)).
+
 
 0.5.3
 =====

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+
+master
+======
+
+
+0.5.5
+=====
+
+- Fixed inconsistent version in `cloudpickle.__version__`.
+
+
 0.5.4
 =====
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 master
 ======
 
-- global variables from modules referenced in sys.modules in the child process
-  now overrides the initial global variables of the pickled function.
+  - Ensure that unpickling a locally defined function that accesses the global variables
+  of a module does not reset the values of the global variables if they are already initialized.
   ([issue #187](https://github.com/cloudpipe/cloudpickle/issues/187))
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@ master
 ======
 
 - global variables from modules referenced in sys.modules in the child process
-  now overrides the initial global variables of the pickled function
+  now overrides the initial global variables of the pickled function.
+  ([issue #187](https://github.com/cloudpipe/cloudpickle/issues/187))
 
 
 0.5.5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
-
 master
 ======
+
+- global variables from modules referenced in sys.modules in the child process
+  now overrides the initial global variables of the pickled function
 
 
 0.5.5
@@ -18,7 +20,6 @@ master
 - Fixed a bug when pickling functions in `__main__` that access global
   variables ([issue #187](
   https://github.com/cloudpipe/cloudpickle/issues/187)).
-
 
 0.5.3
 =====

--- a/cloudpickle/__init__.py
+++ b/cloudpickle/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from cloudpickle.cloudpickle import *
 
-__version__ = '0.5.3'
+__version__ = '0.5.5'

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1092,8 +1092,8 @@ def _make_skel_func(code, cell_count, base_globals=None):
         base_globals = {}
     elif isinstance(base_globals, str):
         if base_globals in sys.modules.keys():
-            # check if we can import the previous environment the object lived
-            # in
+            # this checks if we can import the previous environment the object
+            # lived in
             base_globals = vars(sys.modules[base_globals])
         else:
             base_globals = {}

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -81,6 +81,7 @@ else:
 # cache that tracks the values of global variables.
 _BASE_GLOBALS_CACHE = {}
 
+
 def _make_cell_set_template_code():
     """Get the Python compiler to emit LOAD_FAST(arg); STORE_DEREF
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -56,7 +56,6 @@ import sys
 import traceback
 import types
 import weakref
-import hashlib
 
 
 # cloudpickle is meant for inter process communication: we expect all

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -79,8 +79,8 @@ else:
     PY3 = True
 
 
-# cache that tracks the values of global variables.
-_BASE_GLOBALS_CACHE = {}
+# caches dynamic modules that are not referenced in sys.modules
+_dynamic_modules = {}
 
 
 def _make_cell_set_template_code():
@@ -1096,15 +1096,15 @@ def _make_skel_func(code, cell_count, base_globals=None):
         base_globals = {}
     elif isinstance(base_globals, str):
         base_globals_name = base_globals
-        if base_globals in sys.modules.keys():
+        if base_globals_name in sys.modules.keys():
             # this checks if we can import the previous environment the object
             # lived in
-            base_globals = vars(sys.modules[base_globals])
-        elif base_globals in _BASE_GLOBALS_CACHE.keys():
-            base_globals = _BASE_GLOBALS_CACHE[base_globals]
+            base_globals = vars(sys.modules[base_globals_name])
+        elif base_globals_name in _dynamic_modules.keys():
+            base_globals = _dynamic_modules[base_globals_name]
         else:
             base_globals = {}
-            _BASE_GLOBALS_CACHE[base_globals_name] = base_globals
+            _dynamic_modules[base_globals_name] = base_globals
 
     base_globals['__builtins__'] = __builtins__
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -78,9 +78,6 @@ else:
     PY3 = True
 
 
-# caches dynamic modules that are not referenced in sys.modules
-_dynamic_modules_globals = {}
-
 
 def _make_cell_set_template_code():
     """Get the Python compiler to emit LOAD_FAST(arg); STORE_DEREF
@@ -1094,14 +1091,12 @@ def _make_skel_func(code, cell_count, base_globals=None):
     if base_globals is None:
         base_globals = {}
     elif isinstance(base_globals, str):
-        base_globals_name = base_globals
-        if base_globals_name in sys.modules.keys():
+        if sys.modules.get(base_globals, None) is not None:
             # this checks if we can import the previous environment the object
             # lived in
-            base_globals = vars(sys.modules[base_globals_name])
+            base_globals = vars(sys.modules[base_globals])
         else:
-            base_globals = _dynamic_modules_globals.get(base_globals_name, {})
-            _dynamic_modules_globals[base_globals_name] = base_globals
+            base_globals = {}
 
     base_globals['__builtins__'] = __builtins__
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -79,7 +79,7 @@ else:
 
 
 # caches dynamic modules that are not referenced in sys.modules
-_dynamic_modules = {}
+_dynamic_modules_globals = {}
 
 
 def _make_cell_set_template_code():
@@ -1100,8 +1100,8 @@ def _make_skel_func(code, cell_count, base_globals=None):
             # lived in
             base_globals = vars(sys.modules[base_globals_name])
         else:
-            base_globals = _dynamic_modules.get(base_globals_name, {})
-            _dynamic_modules[base_globals_name] = base_globals
+            base_globals = _dynamic_modules_globals.get(base_globals_name, {})
+            _dynamic_modules_globals[base_globals_name] = base_globals
 
     base_globals['__builtins__'] = __builtins__
 

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1099,10 +1099,8 @@ def _make_skel_func(code, cell_count, base_globals=None):
             # this checks if we can import the previous environment the object
             # lived in
             base_globals = vars(sys.modules[base_globals_name])
-        elif base_globals_name in _dynamic_modules.keys():
-            base_globals = _dynamic_modules[base_globals_name]
         else:
-            base_globals = {}
+            base_globals = _dynamic_modules.get(base_globals_name, {})
             _dynamic_modules[base_globals_name] = base_globals
 
     base_globals['__builtins__'] = __builtins__

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -635,11 +635,12 @@ class CloudPickler(Pickler):
 
         base_globals = self.globals_ref.get(id(func.__globals__), None)
         if base_globals is None:
-            # For functions defined in __main__, use vars(__main__) for
-            # base_global. This is necessary to share the global variables
-            # across multiple functions in this module.
-            if func.__module__ == "__main__":
-                base_globals = "__main__"
+            # For functions defined in a well behaved module use
+            # vars(func.__module__) for base_globals. This is necessary to
+            # share the global variables across multiple pickled functions from
+            # this module.
+            if hasattr(func, '__module__') and func.__module__ is not None:
+                base_globals = func.__module__
             else:
                 base_globals = {}
         self.globals_ref[id(func.__globals__)] = base_globals

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -1091,7 +1091,13 @@ def _make_skel_func(code, cell_count, base_globals=None):
     if base_globals is None:
         base_globals = {}
     elif isinstance(base_globals, str):
-        base_globals = vars(sys.modules[base_globals])
+        if base_globals in sys.modules.keys():
+            # check if we can import the previous environment the object lived
+            # in
+            base_globals = vars(sys.modules[base_globals])
+        else:
+            base_globals = {}
+
     base_globals['__builtins__'] = __builtins__
 
     closure = (

--- a/cloudpickle/cloudpickle.py
+++ b/cloudpickle/cloudpickle.py
@@ -78,7 +78,6 @@ else:
     PY3 = True
 
 
-
 def _make_cell_set_template_code():
     """Get the Python compiler to emit LOAD_FAST(arg); STORE_DEREF
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 dist = setup(
     name='cloudpickle',
-    version='0.5.3',
+    version='0.5.4',
     description='Extended pickling support for Python objects',
     author='Cloudpipe',
     author_email='cloudpipe@googlegroups.com',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 dist = setup(
     name='cloudpickle',
-    version='0.5.4',
+    version='0.5.5',
     description='Extended pickling support for Python objects',
     author='Cloudpipe',
     author_email='cloudpipe@googlegroups.com',

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -929,10 +929,10 @@ class CloudPickleTest(unittest.TestCase):
         this test verifies that:
         - any modification in the global variables of a dynamic
         module living in a child process won't get overridden
-        when new object are unpickled in the child's interpreter
+        when new objects are unpickled in the child's interpreter
 
         - vice versa, e.g a modification in the parent process does not
-        override the value of the variable in the child process
+        override the value of the variables in the child process
 
         The two cases are equivalent, and here, the second case is tested.
         """
@@ -969,6 +969,7 @@ class CloudPickleTest(unittest.TestCase):
 
             # change the mod's global variable x
             mod.x = 2
+
             # at this point, mod.func_that_relies_on_dynamic_module()
             # returns 2
             assert mod.func_that_relies_on_dynamic_module() == 2

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -983,7 +983,7 @@ class CloudPickleTest(unittest.TestCase):
                     first_f = pickle.load(fid)
 
                 # at this point, a module called 'mod' should exist in
-                # _dynamic_modules. further function loading
+                # _dynamic_modules_globals. further function loading
                 # will use the globals living in mod
 
                 assert first_f() == 1
@@ -993,7 +993,7 @@ class CloudPickleTest(unittest.TestCase):
                     new_f = pickle.load(fid)
 
                 # assert the initial global got overridden by
-                # _dynamic_modules
+                # _dynamic_modules_globals
                 assert new_f()==1
 
                 # both function's global x should point to the

--- a/tests/cloudpickle_test.py
+++ b/tests/cloudpickle_test.py
@@ -454,7 +454,6 @@ class CloudPickleTest(unittest.TestCase):
         exec(textwrap.dedent(code), mod.__dict__)
 
         # this script will be ran in a separate child process
-
         # it will import the pickled dynamic module, and then
         # re-pickle it under a new name.
         # finally, it will create a child process that will
@@ -465,6 +464,7 @@ class CloudPickleTest(unittest.TestCase):
 
             import cloudpickle
             from testutils import assert_run_python_script
+
 
             child_of_child_process_script = {}
 


### PR DESCRIPTION
during unpickling, in order to recreate the previous environnement an object lived in,
the module under the `base_globals` name is re-imported. However, it
is not always possible, especially if `base_globals` pointed to a
temporary or locally defined module. This PR introduces a fix that
checks if the module still exists during unpickling. 